### PR TITLE
ed2nav require boost-test...

### DIFF
--- a/builder/Dockerfile-tyr-worker
+++ b/builder/Dockerfile-tyr-worker
@@ -18,6 +18,7 @@ RUN apt-get update && \
                                 libboost-serialization1.55.0 \
                                 libboost-system1.55.0 \
                                 libboost-thread1.55.0 \
+                                libboost-test1.55.0 \
                                 python-dev \
                                 python-pip \
                                 git \


### PR DESCRIPTION
ed2nav: error while loading shared libraries:
libboost_unit_test_framework.so.1.55.0: cannot open shared object file: No such file or directory