### PR TITLE
Use environement variable to define the image's tag to use

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+TAG=latest

--- a/README.md
+++ b/README.md
@@ -46,5 +46,10 @@ To add data to a given instance, you'll need to do:
 
 `docker cp data/dumb_ntfs.zip navitiadockercompose_tyr_worker_1:/srv/ed/input/<my_instance>`
 
+# Tweak images
+By default, the tag `:latest` will be used when images are pulled. If you want to use diferent tags, set the `TAG` envar. For instance, to run the `dev` images for development purposes, run:
+
+`TAG=dev docker-compose -f docker-compose.yml -f additional_navitia_instances.yml up`
+
 # TODO
 - move the tyr and kraken images to alpine :wink:

--- a/artemis/docker-artemis-instance.yml
+++ b/artemis/docker-artemis-instance.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   kraken-corr-02:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=corr-02
         - KRAKEN_GENERAL_database=/srv/ed/output/corr-02.nav.lz4
@@ -14,7 +14,7 @@ services:
       - "30000"
 
   kraken-airport-01:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=airport-01
         - KRAKEN_GENERAL_database=/srv/ed/output/airport-01.nav.lz4
@@ -25,7 +25,7 @@ services:
       - "30000"
 
   kraken-prolong-mano:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=prolong-mano
         - KRAKEN_GENERAL_database=/srv/ed/output/prolong-mano.nav.lz4
@@ -36,7 +36,7 @@ services:
       - "30000"
 
   kraken-bibus:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=bibus
         - KRAKEN_GENERAL_database=/srv/ed/output/bibus.nav.lz4
@@ -47,7 +47,7 @@ services:
       - "30000"
 
   kraken-mission:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=mission
         - KRAKEN_GENERAL_database=/srv/ed/output/mission.nav.lz4
@@ -58,7 +58,7 @@ services:
       - "30000"
 
   kraken-test-02:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=test-02
         - KRAKEN_GENERAL_database=/srv/ed/output/test-02.nav.lz4
@@ -69,7 +69,7 @@ services:
       - "30000"
 
   kraken-sherbrooke:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=sherbrooke
         - KRAKEN_GENERAL_database=/srv/ed/output/sherbrooke.nav.lz4
@@ -80,7 +80,7 @@ services:
       - "30000"
 
   kraken-stif:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=stif
         - KRAKEN_GENERAL_database=/srv/ed/output/stif.nav.lz4
@@ -91,7 +91,7 @@ services:
       - "30000"
 
   kraken-test-03:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=test-03
         - KRAKEN_GENERAL_database=/srv/ed/output/test-03.nav.lz4
@@ -102,7 +102,7 @@ services:
       - "30000"
 
   kraken-nb-corr-05:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=nb-corr-05
         - KRAKEN_GENERAL_database=/srv/ed/output/nb-corr-05.nav.lz4
@@ -113,7 +113,7 @@ services:
       - "30000"
 
   kraken-rebroussement:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=rebroussement
         - KRAKEN_GENERAL_database=/srv/ed/output/rebroussement.nav.lz4
@@ -124,7 +124,7 @@ services:
       - "30000"
 
   kraken-map:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=map
         - KRAKEN_GENERAL_database=/srv/ed/output/map.nav.lz4
@@ -135,7 +135,7 @@ services:
       - "30000"
 
   kraken-fr-pdl:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=fr-pdl
         - KRAKEN_GENERAL_database=/srv/ed/output/fr-pdl.nav.lz4
@@ -146,7 +146,7 @@ services:
       - "30000"
 
   kraken-nb-corr-04:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=nb-corr-04
         - KRAKEN_GENERAL_database=/srv/ed/output/nb-corr-04.nav.lz4
@@ -157,7 +157,7 @@ services:
       - "30000"
 
   kraken-freqgtfs:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=freqgtfs
         - KRAKEN_GENERAL_database=/srv/ed/output/freqgtfs.nav.lz4
@@ -168,7 +168,7 @@ services:
       - "30000"
 
   kraken-corr-01:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=corr-01
         - KRAKEN_GENERAL_database=/srv/ed/output/corr-01.nav.lz4
@@ -179,7 +179,7 @@ services:
       - "30000"
 
   kraken-passe-minuit-01:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=passe-minuit-01
         - KRAKEN_GENERAL_database=/srv/ed/output/passe-minuit-01.nav.lz4
@@ -190,7 +190,7 @@ services:
       - "30000"
 
   kraken-guichet-unique:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=guichet-unique
         - KRAKEN_GENERAL_database=/srv/ed/output/guichet-unique.nav.lz4
@@ -206,7 +206,7 @@ services:
       - "30000"
 
   kraken-freqparis:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=freqparis
         - KRAKEN_GENERAL_database=/srv/ed/output/freqparis.nav.lz4
@@ -217,7 +217,7 @@ services:
       - "30000"
 
   kraken-itl:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=itl
         - KRAKEN_GENERAL_database=/srv/ed/output/itl.nav.lz4
@@ -228,7 +228,7 @@ services:
       - "30000"
 
   kraken-poitiers:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=poitiers
         - KRAKEN_GENERAL_database=/srv/ed/output/poitiers.nav.lz4
@@ -239,7 +239,7 @@ services:
       - "30000"
 
   kraken-test-01:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=test-01
         - KRAKEN_GENERAL_database=/srv/ed/output/test-01.nav.lz4
@@ -250,7 +250,7 @@ services:
       - "30000"
 
   kraken-boucle-01:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=boucle-01
         - KRAKEN_GENERAL_database=/srv/ed/output/boucle-01.nav.lz4
@@ -261,7 +261,7 @@ services:
       - "30000"
 
   kraken-paysdelaloire:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=paysdelaloire
         - KRAKEN_GENERAL_database=/srv/ed/output/paysdelaloire.nav.lz4
@@ -272,7 +272,7 @@ services:
       - "30000"
 
   kraken-saintomer:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=saintomer
         - KRAKEN_GENERAL_database=/srv/ed/output/saintomer.nav.lz4
@@ -283,7 +283,7 @@ services:
       - "30000"
 
   kraken-airport:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=airport
         - KRAKEN_GENERAL_database=/srv/ed/output/airport.nav.lz4
@@ -294,7 +294,7 @@ services:
       - "30000"
 
   kraken-tcl:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=tcl
         - KRAKEN_GENERAL_database=/srv/ed/output/tcl.nav.lz4
@@ -305,7 +305,7 @@ services:
       - "30000"
 
   kraken-passe-minuit-02:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=passe-minuit-02
         - KRAKEN_GENERAL_database=/srv/ed/output/passe-minuit-02.nav.lz4
@@ -316,7 +316,7 @@ services:
       - "30000"
 
   kraken-nb-corr-01:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=nb-corr-01
         - KRAKEN_GENERAL_database=/srv/ed/output/nb-corr-01.nav.lz4
@@ -327,7 +327,7 @@ services:
       - "30000"
 
   kraken-mdi:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=mdi
         - KRAKEN_GENERAL_database=/srv/ed/output/mdi.nav.lz4
@@ -338,7 +338,7 @@ services:
       - "30000"
 
   kraken-nb-corr-03:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=nb-corr-03
         - KRAKEN_GENERAL_database=/srv/ed/output/nb-corr-03.nav.lz4
@@ -349,7 +349,7 @@ services:
       - "30000"
 
   kraken-prolong-auto:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=prolong-auto
         - KRAKEN_GENERAL_database=/srv/ed/output/prolong-auto.nav.lz4
@@ -360,7 +360,7 @@ services:
       - "30000"
 
   kraken-nb-corr-02:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=nb-corr-02
         - KRAKEN_GENERAL_database=/srv/ed/output/nb-corr-02.nav.lz4
@@ -371,7 +371,7 @@ services:
       - "30000"
 
   kraken-freqsimple:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=freqsimple
         - KRAKEN_GENERAL_database=/srv/ed/output/freqsimple.nav.lz4
@@ -382,7 +382,7 @@ services:
       - "30000"
 
   kraken-freqgtfs-01:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=freqgtfs-01
         - KRAKEN_GENERAL_database=/srv/ed/output/freqgtfs-01.nav.lz4
@@ -393,7 +393,7 @@ services:
       - "30000"
 
   kraken-tad:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=tad
         - KRAKEN_GENERAL_database=/srv/ed/output/tad.nav.lz4
@@ -404,7 +404,7 @@ services:
       - "30000"
 
   kraken-fr-auv:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=fr-auv
         - KRAKEN_GENERAL_database=/srv/ed/output/fr-auv.nav.lz4

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -43,7 +43,7 @@ while getopts "lrnb:u:p:" opt; do
             user=$OPTARG
             ;;
         n)
-            navitia_local=0
+            navitia_local=1
             ;;
         l)
             tag_latest=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   instances_configurator:
-    image: navitia/instances-configurator:latest
+    image: navitia/instances-configurator:${TAG}
     volumes_from:
       - tyr_beat
       - jormungandr
@@ -25,7 +25,7 @@ services:
     image: redis:3-alpine
 
   kraken-default:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name=default
         - KRAKEN_GENERAL_database=/srv/ed/output/default.nav.lz4
@@ -36,7 +36,7 @@ services:
       - "30000"
 
   jormungandr:
-    image: navitia/jormungandr:latest
+    image: navitia/jormungandr:${TAG}
     environment:
       - JORMUNGANDR_SQLALCHEMY_DATABASE_URI=postgresql://navitia:navitia@database/jormungandr
       - JORMUNGANDR_INSTANCE_DEFAULT={"key":"default","zmq_socket":"tcp://kraken-default:30000"}
@@ -44,7 +44,7 @@ services:
       - "9191:80"
 
   tyr_worker:
-    image: navitia/tyr-worker:latest
+    image: navitia/tyr-worker:${TAG}
     volumes_from:
       - tyr_beat
     environment:
@@ -52,13 +52,13 @@ services:
       - TYR_CITIES_OSM_FILE_PATH=/srv/ed/
 
   tyr_beat:
-    image: navitia/tyr-beat:latest
+    image: navitia/tyr-beat:${TAG}
     volumes:
       - tyr_data:/srv/ed
       - tyr_instance_conf:/etc/tyr.d
 
   tyr_web:
-    image: navitia/tyr-web:latest
+    image: navitia/tyr-web:${TAG}
     volumes_from:
       - tyr_beat
     ports:

--- a/docker-instances.jinja2
+++ b/docker-instances.jinja2
@@ -3,7 +3,7 @@ version: '2'
 services:
 {% for instance in instances %}
   kraken-{{instance}}:
-    image: navitia/kraken:latest
+    image: navitia/kraken:${TAG}
     environment:
         - KRAKEN_GENERAL_instance_name={{instance}}
         - KRAKEN_GENERAL_database=/srv/ed/output/{{instance}}.nav.lz4


### PR DESCRIPTION
Images's tag to pull can be set via 2 options:
- Change the `TAG` value in the `.env` file
- Use a var env to override the default value when running docker-compose: `TAG=dev docker-compose -f docker-compose.yml -f additional_navitia_instances.yml up`