### PR TITLE
Expose kirin db port on another port

### DIFF
--- a/kirin/docker-compose_kirin.yml
+++ b/kirin/docker-compose_kirin.yml
@@ -26,7 +26,7 @@ services:
       - POSTGRES_PASSWORD=navitia
       - POSTGRES_DB=kirin
     ports:
-     - "15432:5432"
+     - "9494:5432"
 
   kirin_configurator:
     image: kirin_configurator:${KIRIN_TAG}


### PR DESCRIPTION
As `:15432` is often used for postgresql config locally

:warning: change your artemis config if you use that already