### PR TITLE
Update Dockerfiles for nav/python on debian

### DIFF
--- a/builder/Dockerfile-jormungandr
+++ b/builder/Dockerfile-jormungandr
@@ -5,30 +5,20 @@ COPY navitia/source/jormungandr/requirements.txt /usr/src/app
 COPY navitia/source/jormungandr/jormungandr /usr/src/app/jormungandr
 COPY navitia/source/navitiacommon/navitiacommon /usr/src/app/navitiacommon
 
-RUN echo @testing http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
-
-RUN apk --update --no-cache add \
-        g++ \
-        build-base \
+RUN apt-get update --fix-missing \
+    &&  apt-get upgrade -y \
+    &&  apt-get install -y \
+        build-essential \
         python-dev \
-        git \
-        geos@testing \
-        postgresql-dev \
-        libxslt \
-        libxml2-dev \
-        libxslt-dev \
-        libpq \
-        curl && \
-    pip install --no-cache-dir -r requirements.txt && \
-    apk --no-cache del \
-        g++ \
-        build-base \
+        libgeos-c1 \
+        libpq-dev \
+        python-setuptools \
+        curl \
+    &&  pip install --no-cache-dir -r requirements.txt \
+    &&  apt-get autoremove -y \
+        build-essential \
         python-dev \
-        zlib-dev \
-        musl-dev \
-        postgresql-dev \
-        libxml2-dev \
-        libxslt-dev
+        python-setuptools
 
 # ....
 # I don't see a better way, geos try to find libc and fail, so ugly hack to give it

--- a/builder/Dockerfile-kraken
+++ b/builder/Dockerfile-kraken
@@ -1,6 +1,6 @@
 FROM debian:8
 
-RUN apt-get update && \
+RUN apt-get update --fix-missing && \
     apt-get upgrade -y && \
     apt-get install -y libzmq3 \
                       libpqxx-4.0 \

--- a/builder/Dockerfile-mock-kraken
+++ b/builder/Dockerfile-mock-kraken
@@ -1,6 +1,6 @@
 FROM debian:8
 
-RUN apt-get update && \
+RUN apt-get update --fix-missing && \
     apt-get upgrade -y && \
     apt-get install -y libzmq3 \
                       libpqxx-4.0 \

--- a/builder/Dockerfile-tyr-beat
+++ b/builder/Dockerfile-tyr-beat
@@ -7,23 +7,25 @@ COPY navitia/source/tyr/manage_tyr.py /usr/src/app/
 COPY navitia/source/tyr/migrations /usr/src/app/migrations
 COPY navitia/source/navitiacommon/navitiacommon /usr/src/app/navitiacommon
 
-RUN echo @testing http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 
-RUN apk --update --no-cache add \
-        git \
+RUN apt-get update --fix-missing \
+    &&  apt-get upgrade -y \
+    &&  apt-get install -y \
         python-dev \
-        postgresql-dev \
+        build-essential \
+        libgeos-c1 \
+        python-dev \
+        libpq-dev \
         postgresql-client \
-        gcc \
-        geos@testing \
-        musl-dev \
+        python-setuptools \
+    &&  pip install --no-cache-dir -r requirements.txt \
+    &&  pip install --no-cache-dir -U setuptools \
+    &&  apt-get autoremove -y \
         python-dev \
-    && pip install --no-cache-dir -r requirements.txt \
-    && apk --no-cache del \
-            python-dev \
-            git \
-            gcc
-
+        build-essential \ 
+        libpq-dev \
+        python-setuptools
+        
 COPY tyr_settings.py /srv/navitia/settings.py
 
 COPY run_tyr_beat.sh /

--- a/builder/Dockerfile-tyr-web
+++ b/builder/Dockerfile-tyr-web
@@ -6,25 +6,20 @@ COPY navitia/source/tyr/tyr /usr/src/app/tyr
 COPY navitia/source/tyr/manage_tyr.py /usr/src/app/
 COPY navitia/source/navitiacommon/navitiacommon /usr/src/app/navitiacommon
 
-RUN echo @testing http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
-
-RUN apk --update --no-cache add \
-        git \
+RUN apt-get update --fix-missing \
+    &&  apt-get upgrade -y \
+    &&  apt-get install -y \
         python-dev \
-        build-base \
-        linux-headers \
-        postgresql-dev \
-        gcc \
-        geos@testing \
-        musl-dev \
+        build-essential \
+        libgeos-c1 \
+        libpq5 \
+        libpq-dev \
+        python-setuptools \
+    &&  pip install --no-cache-dir -r requirements.txt \
+    &&  apt-get autoremove -y \
         python-dev \
-    && pip install --no-cache-dir -r requirements.txt \
-    && apk --no-cache del \
-            python-dev \
-            git \
-            build-base \
-            linux-headers \
-            gcc
+        build-essential \
+        python-setuptools
 
 COPY tyr_settings.py /srv/navitia/settings.py
 

--- a/builder/Dockerfile-tyr-worker
+++ b/builder/Dockerfile-tyr-worker
@@ -2,7 +2,7 @@ FROM debian:8
 ENV MIMIR_PKG_URL=https://ci.navitia.io/job/mimirsbrunn_release_package/lastSuccessfulBuild/artifact/*zip*/archive.zip
 ENV COSMOGONY2CITIES_PKG_URL=https://ci.navitia.io/view/mimir/job/cosmogony2cities_deb/lastSuccessfulBuild/artifact/*zip*/archive.zip
 
-RUN apt-get update && \
+RUN apt-get update --fix-missing && \
             apt-get upgrade -y && \
             apt-get install -y libpqxx-4.0 \
                                 libgoogle-perftools4 \


### PR DESCRIPTION
After https://github.com/CanalTP/navitia_docker_images/pull/11, the Docker images need to take the debian changes into account.
Will fix https://github.com/CanalTP/navitia-docker-compose/issues/61

- [x] Merge https://github.com/CanalTP/navitia_docker_images/pull/11