### PR TITLE
Update docker-engine install

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -21,10 +21,11 @@ RUN if [ $BUILD -eq 1 ]; then cmake -DCMAKE_BUILD_TYPE=Release source && make -j
 
 WORKDIR /build
 
-RUN apt-get install -y apt-transport-https ca-certificates
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-RUN echo "deb https://apt.dockerproject.org/repo debian-jessie main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -y docker-engine
+RUN apt-get update && apt-get install --fix-missing -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN apt-key fingerprint 0EBFCD88
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+RUN apt-get update && apt-get install -y docker-ce
 
 COPY Dockerfile-jormungandr Dockerfile-jormungandr
 COPY Dockerfile-kraken Dockerfile-kraken

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /build
 
 RUN apt-get update && apt-get install --fix-missing -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN apt-key fingerprint 0EBFCD88
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
 RUN apt-get update && apt-get install -y docker-ce
 


### PR DESCRIPTION
Due to failing jobs in CI:
https://ci.navitia.io/job/navitia-compose-images%20nightly/521/
https://ci.navitia.io/job/navitia-compose-images%20nightly/519/
https://ci.navitia.io/job/navitia-compose-images%20nightly/517/ and so on...
It seems that the way to install docker-engine is old and now unreliable.

Following docker official documentation, the Dockerfile has been updated:
https://docs.docker.com/install/linux/docker-ce/debian/
