### PR TITLE
Add git to install python package from...git

### DIFF
--- a/builder/Dockerfile-jormungandr
+++ b/builder/Dockerfile-jormungandr
@@ -14,11 +14,13 @@ RUN apt-get update --fix-missing \
         libpq-dev \
         python-setuptools \
         curl \
+        git \
     &&  pip install --no-cache-dir -r requirements.txt \
     &&  apt-get autoremove -y \
         build-essential \
         python-dev \
-        python-setuptools
+        python-setuptools \
+        git
 
 # ....
 # I don't see a better way, geos try to find libc and fail, so ugly hack to give it

--- a/builder/Dockerfile-tyr-beat
+++ b/builder/Dockerfile-tyr-beat
@@ -18,13 +18,15 @@ RUN apt-get update --fix-missing \
         libpq-dev \
         postgresql-client \
         python-setuptools \
+        git \
     &&  pip install --no-cache-dir -r requirements.txt \
     &&  pip install --no-cache-dir -U setuptools \
     &&  apt-get autoremove -y \
         python-dev \
         build-essential \ 
         libpq-dev \
-        python-setuptools
+        python-setuptools \
+        git
         
 COPY tyr_settings.py /srv/navitia/settings.py
 

--- a/builder/Dockerfile-tyr-web
+++ b/builder/Dockerfile-tyr-web
@@ -15,11 +15,13 @@ RUN apt-get update --fix-missing \
         libpq5 \
         libpq-dev \
         python-setuptools \
+        git \
     &&  pip install --no-cache-dir -r requirements.txt \
     &&  apt-get autoremove -y \
         python-dev \
         build-essential \
-        python-setuptools
+        python-setuptools \
+        git
 
 COPY tyr_settings.py /srv/navitia/settings.py
 


### PR DESCRIPTION
Since this PR https://github.com/CanalTP/navitia/pull/3195, `ujson` package is installed from a specific commit from git. So it needs to be available in the docker containers.