### PR TITLE
Do not upgrade setuptools, now incompatible py2

### DIFF
--- a/builder/Dockerfile-tyr-beat
+++ b/builder/Dockerfile-tyr-beat
@@ -20,7 +20,6 @@ RUN apt-get update --fix-missing \
         python-setuptools \
         git \
     &&  pip install --no-cache-dir -r requirements.txt \
-    &&  pip install --no-cache-dir -U setuptools \
     &&  apt-get autoremove -y \
         python-dev \
         build-essential \ 

--- a/builder/Dockerfile-tyr-worker
+++ b/builder/Dockerfile-tyr-worker
@@ -52,7 +52,11 @@ RUN wget --quiet $MIMIR_PKG_URL -O /tmp/mimir_pkg.zip && \
     unzip /tmp/cosmo2cities.zip -d /tmp && \
     dpkg -i /tmp/archive/cosmogony2cities*.deb
 
-RUN pip install --upgrade pip && /usr/local/bin/pip install -r /usr/src/app/requirements.txt
+# Use get-pip to upgrade pip without user restrictions
+RUN apt-get install -y curl && curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python2.7 && \
+    pip install --upgrade pip && pip install -r /usr/src/app/requirements.txt && \
+    apt-get autoremove -y  curl
+
 
 EXPOSE 5000
 

--- a/builder/Dockerfile-tyr-worker
+++ b/builder/Dockerfile-tyr-worker
@@ -52,7 +52,7 @@ RUN wget --quiet $MIMIR_PKG_URL -O /tmp/mimir_pkg.zip && \
     unzip /tmp/cosmo2cities.zip -d /tmp && \
     dpkg -i /tmp/archive/cosmogony2cities*.deb
 
-RUN pip install --upgrade pip && pip install setuptools -U && pip install -r /usr/src/app/requirements.txt
+RUN pip install --upgrade pip && /usr/local/bin/pip install -r /usr/src/app/requirements.txt
 
 EXPOSE 5000
 


### PR DESCRIPTION
`setuptools` is now installed in Tyr requirements, so it isn't needed to install it in the Dockerfile:
https://github.com/CanalTP/navitia/blob/68b46a01bc0b8ca776899d0a468dc42a57ae86f0/source/tyr/requirements.txt#L23
It's even not recommended to upgrade the package as the latest versions aren't compatible with Python2:
https://pypi.org/project/setuptools/

Also, in Dockerfile-tyr-worker, the command to upgrade pip didn't work because of ownership:
`Not uninstalling pip at /usr/lib/python2.7/dist-packages, owned by OS`
So, use get-pip: https://pip.pypa.io/en/latest/installing/#installing-with-get-pip-py