### PR TITLE
freeze rabbitmq version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     image: mdillon/postgis:9.5
 
   rabbitmq:
-    image: rabbitmq:management
+    image: rabbitmq:3.8-management
 
   redis:
     image: redis:3-alpine


### PR DESCRIPTION
Navitia is currently not working with rabbitmq v3.9.
Let's use v3.8 until the problem is fixed